### PR TITLE
Update explanation of appearance: none; effect on <input type="search…

### DIFF
--- a/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
@@ -100,7 +100,7 @@ In most cases, the effect is to remove the stylized border, which makes CSS styl
 
 ### Taming search boxes
 
-[`<input type="search">`](/en-US/docs/Web/HTML/Reference/Elements/input/search) is basically just a text input, so why is `appearance: none;` useful here? The answer is that Safari search boxes have some styling restrictions — you can't adjust their `height` or `font-size` freely, for example.
+[`<input type="search">`](/en-US/docs/Web/HTML/Reference/Elements/input/search) is basically just a text input, so why is `appearance: none;` useful here? The answer is that Safari search boxes have traditionally had styling restrictions — for example, older versions did not allow freely adjusting their `height` or `font-size`. However, as of Safari 16 and later, applying `appearance: none;` to general input elements also affects `<input type="search">`, making such restrictions no longer apply. For better compatibility, it’s still recommended to target `input[type="search"]` explicitly.
 
 This can be fixed using our friend `appearance: none;`, which disables the default appearance:
 


### PR DESCRIPTION
…"> in Safari 16+

Update explanation of appearance: none; effect on <input type="search"> in Safari 16+

Clarified that Safari 16 and later versions remove native styling restrictions on <input type="search"> inputs, allowing the use of `appearance: none;` on general input elements to enable flexible styling. This update improves accuracy of the documentation and reflects the latest Safari behavior.

source: https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Clarified that Safari 16+ removed styling restrictions on <input type="search">, allowing `appearance: none;` for flexible styling.

### Motivation

The previous documentation was outdated regarding Safari's behavior. This update improves accuracy and helps developers style search inputs consistently.

### Additional details

[Safari 16 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes)


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
